### PR TITLE
Prepends only new links based on datetime

### DIFF
--- a/src/extparse.py
+++ b/src/extparse.py
@@ -29,7 +29,7 @@ new_links = []
 
 for chat in chats:
     date = chat.date
-    if date < last_datetime:
+    if date <= last_datetime:
         break
 
     tags, link = getTags(chat.message)

--- a/src/extparse.py
+++ b/src/extparse.py
@@ -1,59 +1,43 @@
-from telethon import TelegramClient, sync
+from telethon import TelegramClient
 import pandas as pd
-import json 
 
 api_id = 2899
 api_hash = '36722c72256a24c1225de00eb6a1ca74'
-client = TelegramClient('session_name', api_id, api_hash).start()
 group_username = 'link_dump'
-client.start()
+NUM_MESSAGES = 10*10*100  # last 10 links per 10 users over 100 days 
 
-participants = client.get_participants(group_username)
 
-username = []
-if len(participants):
-    for x in participants:
-        username.append(x.username)
+client = TelegramClient('session_name', api_id, api_hash)
 
-def createRow(date, user, tags, link):
-    row = [date, user]
-    # Append tags
-    for tag in tags:
-        row.append(tag)
-    row.append(link)
-    return row
-    
-def getTags(tagsText):
-    tagsText = tagsText.replace('\n','')
-    tagsText.strip()
-    tagList = tagsText.split(',')
-    while( len(tagList) < 4 ):
-        tagList.append('')
-    return tagList[:4]
+async with client:
+    chats = await client.get_messages(group_username, NUM_MESSAGES)
 
-outCSV = pd.read_csv("/home/radone/LINK_PUMP/src/data_dummy.csv", error_bad_lines=False)
-#outCSV.write('Date,User,Tag1,Tag2,Tag3,Link\n')  
-delimiter = ','
-#outCSV.write(delimiter.join(header)+'\n')
+previous_links_df = pd.read_csv("data_dummy.csv", error_bad_lines=False, parse_dates=['Date'])
 
-chats =client.get_messages(group_username, 100000)
-# n number of messages to be extracted
+last_datetime = max(previous_links_df.Date)
+
+def getTags(message):
+    tagList = message.replace('\n','').strip().split(',')
+    link = tagList[-1]
+    tags = tagList[:-1] 
+    tags += ['']*(3 - len(tags))
+    return tags, link
+
+
 # Get message id, message, sender id, reply to message id, and timestamp
+new_links = []
 
-if len(chats):
-    for chat in chats:
-        cur=str(chat.message)
-        data = ['','','','']
-        foundLink = False
-        data=getTags(cur)
-        tags=data[:3]
-        link=data[3]
-        sender= chat.get_sender().username
-        print(sender)
-        row = createRow(str(chat.date),str(sender), tags, link)
-        #delimiter = ','
-        #row=delimiter.join(row)+'\n'
-        outCSV.append(pd.DataFrame(row))
-print(outCSV)
+for chat in chats:
+    date = chat.date
+    if date < last_datetime:
+        break
 
+    tags, link = getTags(chat.message)
+    sender = chat.get_sender().username
+    new_links.append([str(date), str(sender)] + tags + [link])
+    
 
+new_links_df = pd.DataFrame(new_links, columns=previous_links_df.columns)
+
+new_links_df.append(previous_links_df) \
+            .to_csv('data_dummy.csv', index=False)


### PR DESCRIPTION
This change will prepend only new links by the following flow
- Gets last 10K messages from the group ( in reverse chronological order)
- Fetching DateTime stamp of the last message in the group
- Parse message and add if it more recent than the last message from the previous update
- Prepend those messages and save the file